### PR TITLE
SITES-29453 - Make ContentFragments Delivery API documentation stable.

### DIFF
--- a/src/pages/api/experimental/sites/delivery/index.md
+++ b/src/pages/api/experimental/sites/delivery/index.md
@@ -1,4 +1,0 @@
----
-title: Sites Delivery API
-frameSrc: https://adobe-aem-sites-delivery-fragmentdelivery.redoc.ly/
---- 

--- a/src/pages/api/stable/contentfragments/delivery/index.md
+++ b/src/pages/api/stable/contentfragments/delivery/index.md
@@ -1,0 +1,4 @@
+---
+title: Sites Delivery API
+frameSrc: https://adobe-aem-contentfragments-delivery.redoc.ly
+--- 

--- a/src/pages/api/stable/contentfragments/delivery/index.md
+++ b/src/pages/api/stable/contentfragments/delivery/index.md
@@ -1,4 +1,4 @@
 ---
-title: Sites Delivery API
+title: AEM Content Fragment Delivery with OpenAPI
 frameSrc: https://adobe-aem-contentfragments-delivery.redoc.ly
 --- 

--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -15,7 +15,7 @@ A comprehensive content management solution for building websites, mobile apps a
 
 ### Delivery
 
-* [Content Fragments and Model Delivery (Experimental)](./api/experimental/sites/delivery/)
+* [Content Fragment Delivery with OpenAPI](./api/stable/contentfragments/delivery/)
 * [Dynamic Media with Open API](./api/stable/assets/delivery/index.md)
 
 <DiscoverBlock slots="heading, link, text"/>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Moving the Content Fragments Delivery API documentation under stable folder.

## Motivation and Context

The Content Fragments Delivery API is considered now stable.

## How Has This Been Tested?

Ran yarn dev and browsed the documentation locally.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
