### PR TITLE
ASSETS-50826 - Fix broken link in documentation to Assets events

### DIFF
--- a/src/pages/guides/events/index.md
+++ b/src/pages/guides/events/index.md
@@ -58,7 +58,7 @@ AEM events are routed to Adobe I/O by default and are available instantly as soo
 Current available event types are documented in the AEM API specification as listed below:
 
 * [AEM Sites Author Events](https://developer.adobe.com/experience-cloud/experience-manager-apis/api/stable/sites/)
-* [AEM Assets Author Events](https://developer.adobe.com/experience-cloud/experience-manager-apis/api/experimental/assets/author/)
+* [AEM Assets Author Events](https://developer.adobe.com/experience-cloud/experience-manager-apis/api/stable/assets/author/)
 
 <InlineAlert slots="text" />
 


### PR DESCRIPTION
## Description

Updated broken link.  This was introduced when we moved the Assets API schema from experimental to stable.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)