### PR TITLE
feature: consume the Assets Author OpenAPI from Redocly without iframes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -150,6 +150,7 @@ jobs:
           GATSBY_ALGOLIA_SEARCH_INDEX: ${{ secrets.AIO_ALGOLIA_SEARCH_INDEX }}
           GATSBY_ALGOLIA_INDEX_ENV_PREFIX: ${{ secrets.AIO_ALGOLIA_INDEX_ENV_PREFIX }}
           GATSBY_FEDS_PRIVACY_ID: ${{ secrets.AIO_FEDS_PRIVACY_ID }}
+          GATSBY_REDOCLY_KEY: ${{ secrets.REDOCLY_LICENSE_KEY }}
           GATSBY_SITE_DOMAIN_URL: https://developer-stage.adobe.com
 
       - name: Deploy
@@ -257,6 +258,7 @@ jobs:
           GATSBY_ALGOLIA_SEARCH_INDEX: ${{ secrets.AIO_ALGOLIA_SEARCH_INDEX }}
           GATSBY_ALGOLIA_INDEX_ENV_PREFIX: ${{ secrets.AIO_ALGOLIA_INDEX_ENV_PREFIX }}
           GATSBY_FEDS_PRIVACY_ID: ${{ secrets.AIO_FEDS_PRIVACY_ID }}
+          GATSBY_REDOCLY_KEY: ${{ secrets.REDOCLY_LICENSE_KEY }}
           GATSBY_SITE_DOMAIN_URL: https://developer.adobe.com
       - name: Deploy
         uses: AdobeDocs/static-website-deploy@master

--- a/src/pages/api/stable/assets/author/index.md
+++ b/src/pages/api/stable/assets/author/index.md
@@ -1,4 +1,4 @@
 ---
 title: Assets Author API
-frameSrc: https://adobe-aem-assets-author.redoc.ly/
 --- 
+<RedoclyAPIBlock src="https://api.redocly.com/registry/bundle/adobe-developers/AEM-assets-author/stable/openapi.yaml?branch=prod" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The previous way to render the Redocly playgrounds relied on using `iframes`, which was problematic when sending link to customers since they would use the redocly domains. With the use of the `RedoclyAPIBlock` we can render the API on our own domain.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
