### PR TITLE
GRANITE-66942 - Update content ai docs

### DIFF
--- a/src/pages/api/experimental/contentai-legacy/index.md
+++ b/src/pages/api/experimental/contentai-legacy/index.md
@@ -3,4 +3,4 @@ title: Content AI Services OpenAPI
 layout: none
 ---
 
-<RedoclyAPIBlock src='https://api.redocly.com/registry/bundle/adobe-developers/AEM-contentAI/contentai-legacy/openapi.yaml?branch=prod' typography='fontFamily: `"Source Sans Pro", sans-serif`' />
+<RedoclyAPIBlock src='https://api.redocly.com/registry/bundle/adobe-developers/AEM-contentAI/contentai/openapi.yaml?branch=prod' typography='fontFamily: `"Source Sans Pro", sans-serif`' />

--- a/src/pages/api/experimental/contentai-legacy/index.md
+++ b/src/pages/api/experimental/contentai-legacy/index.md
@@ -1,0 +1,6 @@
+---
+title: Content AI Services OpenAPI
+layout: none
+---
+
+<RedoclyAPIBlock src='https://api.redocly.com/registry/bundle/adobe-developers/AEM-contentAI/contentai-legacy/openapi.yaml?branch=prod' typography='fontFamily: `"Source Sans Pro", sans-serif`' />

--- a/src/pages/api/experimental/contentai/index.md
+++ b/src/pages/api/experimental/contentai/index.md
@@ -1,5 +1,5 @@
 ---
-title: Content AI Services OpenAPI
+title: Content AI OpenAPI
 layout: none
 ---
 

--- a/src/pages/api/experimental/contentai/index.md
+++ b/src/pages/api/experimental/contentai/index.md
@@ -3,4 +3,4 @@ title: Content AI OpenAPI
 layout: none
 ---
 
-<RedoclyAPIBlock src='https://api.redocly.com/registry/bundle/adobe-developers/AEM-contentAI/contentai/openapi.yaml?branch=prod' typography='fontFamily: `"Source Sans Pro", sans-serif`' />
+<RedoclyAPIBlock src='https://api.redocly.com/registry/bundle/adobe-developers/AEM-contentAI/aemcontentai/openapi.yaml?branch=prod' typography='fontFamily: `"Source Sans Pro", sans-serif`' />

--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -63,7 +63,7 @@ A comprehensive content management solution for building websites, mobile apps a
 
 **Content AI**
 
-* [Content AI Services API (Experimental)](api/experimental/contentai/index.md)
+* [Content AI API (Experimental)](api/experimental/contentai/index.md)
 
 ## Other HTTP APIs
 


### PR DESCRIPTION
  ## Description

  Publishes the legacy Content AI OpenAPI bundle as a separate docs page and drops "Services" from the current Content AI doc title and homepage link.

  - Adds `src/pages/api/experimental/contentai-legacy/index.md` rendering the `contentai-legacy` bundle from the Redocly registry (`adobe-developers/AEM-contentAI/contentai-legacy/openapi.yaml?branch=prod`).
  - Renames the title of `src/pages/api/experimental/contentai/index.md` from "Content AI Services OpenAPI" to "Content AI OpenAPI".
  - Updates the homepage link label on `src/pages/index.md` from "Content AI Services API (Experimental)" to "Content AI API (Experimental)".

  ## Related Issue

  [GRANITE-66942](https://jira.corp.adobe.com/browse/GRANITE-66942)

  ## Motivation and Context

  The Content AI public API has been reshaped around a content source-scoped contract (`POST /contentAI/content-sources/{name}/search`). The current `POST /search` endpoint now ships from a separate
  `contentai-legacy` bundle in the Redocly registry so clients still on the older contract have a stable reference while they migrate. This PR surfaces both bundles in the public docs site:

  - `/api/experimental/contentai` — current contract (renamed without the redundant "Services" qualifier).
  - `/api/experimental/contentai-legacy` — legacy contract, kept available until the migration window closes.

  ## How Has This Been Tested?

  - The new page reuses the same `<RedoclyAPIBlock>` rendering pattern as the existing `contentai/index.md`; only the bundle URL and title differ.
  - Confirmed the Redocly registry URL `adobe-developers/AEM-contentAI/contentai-legacy/openapi.yaml?branch=prod` resolves to the published bundle.

  ## Screenshots (if appropriate):

  N/A — text-only changes; rendering is delegated to the existing `RedoclyAPIBlock` component.

  ## Types of changes

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)

  ## Checklist:

  - [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
  - [x] My code follows the code style of this project.
  - [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
  - [ ] I have read the **CONTRIBUTING** document.
  - [ ] I have added tests to cover my changes.
  - [x] All new and existing tests passed.