### PR TITLE
ASSETS-75329: Add experimental metaall API doc pages

### DIFF
--- a/src/pages/api/experimental/assets/author/metaall.md
+++ b/src/pages/api/experimental/assets/author/metaall.md
@@ -1,0 +1,6 @@
+---
+title: Assets Author API
+layout: none
+--- 
+
+<RedoclyAPIBlock src='https://api.redocly.com/registry/bundle/adobe-developers/AEM-assets-author/metaall/openapi.yaml?branch=prod' typography='fontFamily: `"Source Sans Pro", sans-serif`' />

--- a/src/pages/api/experimental/folders/metaall.md
+++ b/src/pages/api/experimental/folders/metaall.md
@@ -1,0 +1,6 @@
+---
+title: Folders API
+layout: none
+--- 
+
+<RedoclyAPIBlock src='https://api.redocly.com/registry/bundle/adobe-developers/AEM-folders-author/metaall/openapi.yaml?branch=prod' typography='fontFamily: `"Source Sans Pro", sans-serif`' />

--- a/src/pages/api/experimental/tags/author/metaall.md
+++ b/src/pages/api/experimental/tags/author/metaall.md
@@ -1,0 +1,6 @@
+---
+title: Tags Author API
+layout: none
+--- 
+
+<RedoclyAPIBlock src='https://api.redocly.com/registry/bundle/adobe-developers/AEM-tags-author/metaall/openapi.yaml?branch=prod' typography='fontFamily: `"Source Sans Pro", sans-serif`' />

--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -38,12 +38,20 @@ A comprehensive content management solution for building websites, mobile apps a
 **Assets**
 
 * [Assets Author API](api/stable/assets/author/index.md)
+* [Assets Author API (Experimental)](api/experimental/assets/author/metaall.md)
+
+<DiscoverBlock slots="link, text"/>
+
+**Tags**
+
+* [Tags Author API (Experimental)](api/experimental/tags/author/metaall.md)
 
 <DiscoverBlock slots="link, text"/>
 
 **Folders**
 
 * [Folders API](api/stable/folders/index.md)
+* [Folders API (Experimental)](api/experimental/folders/metaall.md)
 
 <DiscoverBlock slots="link, text"/>
 


### PR DESCRIPTION
## Summary

Adds experimental API reference pages for the AEM author APIs, each embedding its `metaall` Redocly bundle, and links them from the API index.

Jira: [ASSETS-75329](https://jira.corp.adobe.com/browse/ASSETS-75329)

## Changes

- New experimental pages:
  - `src/pages/api/experimental/assets/author/metaall.md` (`AEM-assets-author/metaall`)
  - `src/pages/api/experimental/folders/metaall.md` (`AEM-folders-author/metaall`)
  - `src/pages/api/experimental/tags/author/metaall.md` (`AEM-tags-author/metaall`)
- Linked the three pages under the Assets, Folders, and Tags groups in `src/pages/index.md`.
- The Tags experimental entry points at the long-lived `metaall` bundle (server flag `metaall-expires-20991231`) rather than the near-term `assetfoundation-expires-20261231` bundle.

All three Redocly bundle URLs return HTTP 200 (public, `branch=prod`).
