### PR TITLE
docs: add stable Content AI API reference page

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -180,6 +180,14 @@
       "Destination": "/experience-cloud/experience-manager-apis/api/experimental/document/"
     },
     {
+      "Source": "/experience-cloud/experience-manager-apis/api/stable/contentai",
+      "Destination": "/experience-cloud/experience-manager-apis/api/stable/contentai/"
+    },
+    {
+      "Source": "/experience-cloud/experience-manager-apis/api/stable/contentai/index",
+      "Destination": "/experience-cloud/experience-manager-apis/api/stable/contentai/"
+    },
+    {
       "Source": "/experience-cloud/experience-manager-apis/api/experimental/contentai",
       "Destination": "/experience-cloud/experience-manager-apis/api/experimental/contentai/"
     },

--- a/src/pages/api/stable/contentai/index.md
+++ b/src/pages/api/stable/contentai/index.md
@@ -1,0 +1,6 @@
+---
+title: Content AI OpenAPI
+layout: none
+---
+
+<RedoclyAPIBlock src='https://api.redocly.com/registry/bundle/adobe-developers/AEM-contentAI/stable/openapi.yaml?branch=prod' typography='fontFamily: `"Source Sans Pro", sans-serif`' />

--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -63,7 +63,8 @@ A comprehensive content management solution for building websites, mobile apps a
 
 **Content AI**
 
-* [Content AI Services API (Experimental)](api/experimental/contentai/index.md)
+* [Content AI API](api/stable/contentai/index.md)
+* [Content AI API (Experimental)](api/experimental/contentai/index.md)
 
 ## Other HTTP APIs
 


### PR DESCRIPTION
## Description

Adds a dedicated **stable** Content AI API reference page and links it from the API index, alongside the existing experimental page.

- New page: `src/pages/api/stable/contentai/index.md` — renders the `AEM-contentAI/stable` Redocly bundle (all promoted-to-stable operations: Content Sources acquisition, AI Search, Generative Search).
- `src/pages/index.md` — adds a **Content AI API** bullet under the Content AI section, above the existing **Content AI API (Experimental)** bullet.
- `redirects.json` — adds the two standard redirect entries for the new `api/stable/contentai` path (bare → trailing-slash, `/index` → trailing-slash).

## Related Issue

Depends on api-registry PR #565 (publishes/deploys the `AEM-contentAI/stable` Redocly bundle). This docs page will render empty until #565 merges and the Redocly registry syncs the stable bundle, so it should land after #565.

## Motivation and Context

The Content AI OpenAPI schemas were split into stable vs experimental tiers. The experimental page already exists; this adds the corresponding stable reference so consumers can find the GA surface.

## How Has This Been Tested?

- Verified the new page frontmatter/`RedoclyAPIBlock` matches the existing experimental page's structure.
- Validated `redirects.json` parses as valid JSON.
- Confirmed the stable bundle URL follows the registry's naming convention (`AEM-contentAI/stable`) derived from api-registry `build/deploy_redocly.js`.

## Screenshots (if appropriate):

## Types of changes

- [x] Documentation change

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.